### PR TITLE
fix cache key to correctly include python version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,4 +48,4 @@ runs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
# What Changed

## Fixed

- fixed incorrect output path used when constructing cache key
