### PR TITLE
add `cache-key-suffix` input

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -59,18 +59,6 @@ jobs:
           exit 1
       - name: check poetry
         run: poetry --version
-      - id: local-action-hit
-        uses: ./
-        with:
-          cache-key-suffix: ${{ github.run_number }}
-          python-version: ${{ matrix.python-version }}
-      - name: check outputs.cache-hit (hit)
-        env:
-          CACHE_HIT_VALUE: ${{ steps.local-action-hit.outputs.cache-hit }}
-        if: steps.local-action-hit.outputs.cache-hit != 'true'
-        run: |
-          echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
-          exit 1
   test-local-action-hit:
     # This has to be run after the miss as the cache is not uploaded until the
     # the job is finished.

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -39,6 +39,7 @@ jobs:
       - id: local-action
         uses: ./
         with:
+          cache-key-suffix: ${{ github.run_number }}
           python-version: ${{ matrix.python-version }}
       - name: check outputs.python-version
         env:
@@ -49,5 +50,24 @@ jobs:
           echo "outputs.python-version=${OUTPUTS_PYTHON_VERSION}"
           echo "matrix.python-version=${MATRIX_PYTHON_VERSION}"
           exit 1
+      - name: check outputs.cache-hit (miss)
+        env:
+          CACHE_HIT_VALUE: ${{ steps.local-action.outputs.cache-hit }}
+        if: steps.local-action.outputs.cache-hit == 'true'
+        run:
+          echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
+          exit 1
       - name: check poetry
         run: poetry --version
+      - id: local-action-hit
+        uses: ./
+        with:
+          cache-key-suffix: ${{ github.run_number }}
+          python-version: ${{ matrix.python-version }}
+      - name: check outputs.cache-hit (hit)
+        env:
+          CACHE_HIT_VALUE: ${{ steps.local-action-hit.outputs.cache-hit }}
+        if: steps.local-action-hit.outputs.cache-hit != 'true'
+        run:
+          echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
+          exit 1

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -28,8 +28,8 @@ jobs:
         run: poetry run pip --version > /dev/null 2>&1 || rm -rf .venv
       - run: poetry install -vv --remove-untracked
       - uses: pre-commit/action@v2.0.3
-  test-local-action:
-    name: Test Local Action
+  test-local-action-miss:
+    name: Test Local Action With Cache Miss
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,6 +68,29 @@ jobs:
         env:
           CACHE_HIT_VALUE: ${{ steps.local-action-hit.outputs.cache-hit }}
         if: steps.local-action-hit.outputs.cache-hit != 'true'
+        run: |
+          echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
+          exit 1
+  test-local-action-hit:
+    # This has to be run after the miss as the cache is not uploaded until the
+    # the job is finished.
+    name: Test Local Action With Cache Hit
+    needs: test-local-action-miss
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - id: local-action
+        uses: ./
+        with:
+          cache-key-suffix: ${{ github.run_number }}
+          python-version: ${{ matrix.python-version }}
+      - name: check outputs.cache-hit (hit)
+        env:
+          CACHE_HIT_VALUE: ${{ steps.local-action.outputs.cache-hit }}
+        if: steps.local-action.outputs.cache-hit != 'true'
         run: |
           echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
           exit 1

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -54,7 +54,7 @@ jobs:
         env:
           CACHE_HIT_VALUE: ${{ steps.local-action.outputs.cache-hit }}
         if: steps.local-action.outputs.cache-hit == 'true'
-        run:
+        run: |
           echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
           exit 1
       - name: check poetry
@@ -68,6 +68,6 @@ jobs:
         env:
           CACHE_HIT_VALUE: ${{ steps.local-action-hit.outputs.cache-hit }}
         if: steps.local-action-hit.outputs.cache-hit != 'true'
-        run:
+        run: |
           echo "outputs.cache-hit=${CACHE_HIT_VALUE}"
           exit 1

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ steps:
 
 ### Inputs
 
-| Key            | Description                                                                                                                          |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| architecture   | The target architecture (x86, x64) of the Python interpreter.The target architecture (x86, x64) of the Python interpreter.           |
-| poetry-preview | Allow install of prerelease versions of Poetry.                                                                                      |
-| poetry-version | Poetry version to use. If version is not provided then latest stable version will be used.                                           |
-| python-version | Version range or exact version of a Python version to use, using semver version range syntax.                                        |
-| token          | Used to pull python distributions from actions/python-versions. Since there's a default, this is typically not supplied by the user. |
+| Key              | Description                                                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| architecture     | The target architecture (x86, x64) of the Python interpreter.The target architecture (x86, x64) of the Python interpreter.                       |
+| cache-key-suffix | Temporary input to allow for slight customization of the cache key until full customization can be provided. This will be removed in the future. |
+| poetry-preview   | Allow install of prerelease versions of Poetry.                                                                                                  |
+| poetry-version   | Poetry version to use. If version is not provided then latest stable version will be used.                                                       |
+| python-version   | Version range or exact version of a Python version to use, using semver version range syntax.                                                    |
+| token            | Used to pull python distributions from actions/python-versions. Since there's a default, this is typically not supplied by the user.             |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -3,11 +3,14 @@ description: Setup a specific version of Python & poetry with virtual environmen
 author: Kyle Finley
 branding:
   color: purple
-  icon: coffee
+  icon: cloud-lightning
 
 inputs:
   architecture:
     description: The target architecture (x86, x64) of the Python interpreter.
+  cache-key-suffix:
+    description: Temporary input to allow for slight customization of the cache key until full customization can be provided.
+    required: false
   poetry-preview:
     description: Allow install of prerelease versions of Poetry.
     required: false
@@ -48,4 +51,4 @@ runs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}${{ input.cache-key-suffix }}

--- a/action.yml
+++ b/action.yml
@@ -51,4 +51,4 @@ runs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}${{ input.cache-key-suffix }}
+        key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}${{ inputs.cache-key-suffix }}


### PR DESCRIPTION
# Summary

Add an input option to configure the cache key.

Note that this implementation is temporary. Once conditionals are supported in composite actions, full customization will be added in place of this.

# Why This Is Needed

Without being able to alter the key, I would not be able to test chace hit vs miss.

# What Changed

## Added

- added optikonal `cache-key-suffix` input which is appended to the end of the cache key
