### PR TITLE
use pipx to install poetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
         additional_dependencies:
           - mdformat-frontmatter
           - mdformat-gfm
+          - mdformat-gfm-alerts
           - mdformat-toc
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ A composite GitHub Action that sets up both Python and poetry with virtual envir
 This Action was started because I found myself repeating the same steps over and over again across jobs.
 Since Actions don't currently support YAML anchors, this was my next best option.
 
-> **\[DISCLAIMER\]** This Action can and will undergo breaking changes until there is a v1.0.0.
+> [!CAUTION]
+> This Action can and will undergo breaking changes until there is a `v1.0.0`.
 > There are a few features still lacking from the newly release composite Actions that are needed to improve functionality.
 > The primary feature being support for conditions.
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
+- [Features](#features)
 - [Requirements](#requirements)
 - [Usage](#usage)
   - [Inputs](#inputs)
@@ -18,10 +20,27 @@ Since Actions don't currently support YAML anchors, this was my next best option
 
 <!-- mdformat-toc end -->
 
+## Features
+
+- uses [pipx] to install [poetry]
+  - as of implementation, this is [poetry]'s recommended install method
+  - uses [pipx] that comes pre-installed on all [GitHub Runner images](https://github.com/actions/runner-images#available-images)
+  - caches [pipx] directories
+- sets the following global [poetry] configuration values:
+  - `virtualenvs.create = true`
+  - `virtualenvs.in-project = true`
+  - `virtualenvs.prefer-active-python = true`
+- injects [poetry-plugin-export](https://github.com/python-poetry/poetry-plugin-export) into the [pipx] install of [poetry]
+  - in the future this plugin will not be installed by default with poetry
+  - disables [poetry]'s warning regarding the future remove of this plugin
+- _(optional)_ checks the constancy of `poetry.lock`
+- _(optional)_ installs dependencies using [poetry]
+
 ## Requirements
 
-- [actions/checkout](https://github.com/actions/checkout) needs to be run before this Action
+- [actions/checkout](https://github.com/actions/checkout) needs to be run **before** this Action
 - the virtual environment needs to be created within the project for it to be cached (`poetry config --local virtualenvs.in-project true`)
+  - this is set globally by the action but if it is set to `false` locally, it will take precedence
 
 ## Usage
 
@@ -46,7 +65,7 @@ steps:
 | poetry-install-args     | Additional args to pass to `poetry install`. Defaults to `-vvv --remove-untracked`                                                                                                                                                                                                                         |
 | poetry-install-cmd      | Command for installing poetry project. Can be used to provide a custom install command. The value of `poetry-install-args` is appended after this. Defaults to `poetry install`. This is also a check for the existence of a `Makefile` with a `setup-poetry` target. If found, using it takes precedence. |
 | poetry-preview          | Allow install of prerelease versions of Poetry.                                                                                                                                                                                                                                                            |
-| poetry-version          | Poetry version to use. If version is not provided then latest stable version will be used.                                                                                                                                                                                                                 |
+| poetry-version          | Poetry version to use. If version is not provided then latest stable version will be used. Should be provided as a version specifier that can be passed to [pipx](https://github.com/pypa/pipx) or `latest`                                                                                                |
 | python-version          | Version range or exact version of a Python version to use, using semver version range syntax. Reads from `pyproject.toml` if unset.                                                                                                                                                                        |
 | python-version-file     | File containing the Python version to use.                                                                                                                                                                                                                                                                 |
 | token                   | Used to pull python distributions from actions/python-versions. Since there's a default, this is typically not supplied by the user.                                                                                                                                                                       |
@@ -57,3 +76,6 @@ steps:
 | -------------- | ------------------------------------------------------------------------- |
 | cache-hit      | Whether there was a cache hit for the Python virtual environment.         |
 | python-version | The installed Python version. Useful when given a version range as input. |
+
+[pipx]: https://github.com/pypa/pipx
+[poetry]: https://github.com/python-poetry/poetry

--- a/action.yml
+++ b/action.yml
@@ -28,29 +28,32 @@ inputs:
       The poetry command to run when checking the lock file (e.g. `check`).
       This command was changed in poetry 1.6 (default used by this action).
       To support older versions of poetry, provide a value for this input.
-    required: false
     default: check
+    required: false
   poetry-install:
     description: Whether to run `poetry install`.
     required: false
     default: true
   poetry-install-args:
     description: Additional args to pass to `poetry install`.
-    required: false
     default: '-v --sync'
+    required: false
   poetry-install-cmd:
     description: |
       Command for installing poetry project.
       Can be used to provide a custom install command.
       The value of `poetry-install-args` is appended after this.
-    required: false
     default: poetry install
+    required: false
   poetry-preview:
     description: Allow install of prerelease versions of Poetry.
-    required: false
     default: false
+    required: false
   poetry-version:
-    description: Poetry version to use. If version is not provided then latest stable version will be used.
+    description: |
+      Poetry version to use. If version is not provided then latest stable version will be used.
+      Should be provided as a version specifier that can be passed to [pipx](https://github.com/pypa/pipx) or `latest`.
+    default: "latest"
     required: false
   python-version:
     description: Version range or exact version of a Python version to use, using semver version range syntax. Reads from pyproject.toml if unset.
@@ -77,39 +80,70 @@ outputs:
 runs:
   using: composite
   steps:
-    - id: composite-setup-python-explicit
+    - name: Output pipx variables
+      id: pipx-vars
+      run: |
+        echo "pipx-home=$PIPX_HOME" >> $GITHUB_OUTPUT;
+        echo "pipx-bin-dir=$PIPX_BIN_DIR" >> $GITHUB_OUTPUT;
+      shell: bash
+    - name: Cache pipx
+      id: composit-cache-pipx
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ steps.pipx-vars.outputs.pipx-home }}
+          ${{ steps.pipx-vars.outputs.pipx-bin-dir }}
+        key: pipx-poetry-${{ input.poetry-version }}
+    - name: Install poetry
+      env:
+        INPUT_POETRY_PREVIEW: "${{ inputs.poetry-preview }}"
+        INPUT_POETRY_VERSION: "${{ inputs.poetry-version }}"
+      id: composit-install-poetry
+      if: ${{ steps.composit-cache-pipx.outputs.cache-hit != 'true' }}
+      run: "${GITHUB_ACTION_PATH}/scripts/install-poetry.sh"
+      shell: bash
+    - name: Install poetry-plugin-export
+      if: ${{ steps.composit-cache-pipx.outputs.cache-hit != 'true' }}
+      run: |
+        pipx inject poetry poetry-plugin-export;
+        poetry config warnings.export false;
+      shell: bash
+    - name: Ensure pipx paths
+      run: |
+        pipx ensurepath;
+        pipx list --include-injected;
+      shell: bash
+    - name: Setup python (explicit)
+      id: composite-setup-python-explicit
       if: inputs.python-version != ''
       uses: actions/setup-python@v5
       with:
         architecture: ${{ inputs.architecture }}
         python-version: ${{ inputs.python-version }}
         token: ${{ inputs.token }}
-    - id: composite-setup-python-file
+    - name: Setup python (implicit / file)
+      id: composite-setup-python-file
       if: inputs.python-version == ''
       uses: actions/setup-python@v5
       with:
         architecture: ${{ inputs.architecture }}
         python-version-file: ${{ inputs.python-version-file }}
         token: ${{ inputs.token }}
-    - id: composite-setup-python
-      shell: bash
+    - name: Extract python-version output
+      id: composite-setup-python
       run: |
         if [[ -n "${{ steps.composite-setup-python-explicit.outputs.python-version }}" ]]; then
-          echo "python-version=${{ steps.composite-setup-python-explicit.outputs.python-version }}" >> $GITHUB_OUTPUT ;
+          echo "python-version=${{ steps.composite-setup-python-explicit.outputs.python-version }}" >> $GITHUB_OUTPUT;
         else
-          echo "python-version=${{ steps.composite-setup-python-file.outputs.python-version }}" >> $GITHUB_OUTPUT ;
+          echo "python-version=${{ steps.composite-setup-python-file.outputs.python-version }}" >> $GITHUB_OUTPUT;
         fi
-    - id: composite-setup-poetry
-      uses: Gr1N/setup-poetry@v9
-      with:
-        poetry-preview: ${{ inputs.poetry-preview }}
-        poetry-version: ${{ inputs.poetry-version }}
+      shell: bash
     - id: composite-python-venv-cache
       uses: actions/cache@v4.0.2
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}${{ inputs.cache-key-suffix }}
-    - name: Ensure Cache Is Healthy
+    - name: Ensure cache is healthy
       if: |
         always() &&
         inputs.ensure-cache-is-healthy == 'true' &&
@@ -123,11 +157,11 @@ runs:
         POETRY_CHECK_CMD: ${{ inputs.poetry-check-cmd }}
       run: poetry ${POETRY_CHECK_CMD}
       shell: bash
-    - name: Install Dependencies
+    - name: Install dependencies
       if: inputs.poetry-install == 'true'
       env:
-          POETRY_INSTALL_ARGS: ${{ inputs.poetry-install-args }}
-          POETRY_INSTALL_CMD: ${{ inputs.poetry-install-cmd }}
+        POETRY_INSTALL_ARGS: ${{ inputs.poetry-install-args }}
+        POETRY_INSTALL_CMD: ${{ inputs.poetry-install-cmd }}
       run: |
         if [[ -f "Makefile" ]] && grep -q 'setup-poetry:' Makefile; then
           echo "installing project using Makefile...";

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         path: |
           ${{ steps.pipx-vars.outputs.pipx-home }}
           ${{ steps.pipx-vars.outputs.pipx-bin-dir }}
-        key: pipx-poetry-${{ input.poetry-version }}
+        key: pipx-poetry-${{ inputs.poetry-version }}
     - name: Install poetry
       env:
         INPUT_POETRY_PREVIEW: "${{ inputs.poetry-preview }}"
@@ -101,12 +101,6 @@ runs:
       id: composit-install-poetry
       if: ${{ steps.composit-cache-pipx.outputs.cache-hit != 'true' }}
       run: "${GITHUB_ACTION_PATH}/scripts/install-poetry.sh"
-      shell: bash
-    - name: Install poetry-plugin-export
-      if: ${{ steps.composit-cache-pipx.outputs.cache-hit != 'true' }}
-      run: |
-        pipx inject poetry poetry-plugin-export;
-        poetry config warnings.export false;
       shell: bash
     - name: Ensure pipx paths
       run: |

--- a/scripts/install-poetry.sh
+++ b/scripts/install-poetry.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+set -eo pipefail
+shopt -s extglob
+
+PIP_ARGS="";  # store args to pass to `pipx install --pip-args=...`
+
+if [[ "${INPUT_POETRY_PREVIEW}" == "true" ]]; then
+  PIP_ARGS="--pre";
+fi;
+
+case "${INPUT_POETRY_VERSION}" in
+  latest)
+    pipx install poetry --pip-args="${PIP_ARGS}";
+    ;;
+  ~*|==*|\>*|\<*)
+    pipx install "poetry${INPUT_POETRY_VERSION}" --pip-args="${PIP_ARGS}";
+    ;;
+  @(0|1|2|3|4|5|6|7|8|9)*)
+    echo "poetry-version input appears to contain an explicit version; please add a prefix of '==' to ensure propper functionality";
+    pipx install "poetry==${INPUT_POETRY_VERSION}" --pip-args="${PIP_ARGS}";
+    ;;
+  *)
+    echo "poetry-version input value of ${INPUT_POETRY_VERSION} does not appear to be a valid version specifier or 'latest'";
+    echo "please update the value and try again";
+    exit 1;
+    ;;
+esac
+
+poetry config virtualenvs.create true
+poetry config virtualenvs.in-project true
+poetry config virtualenvs.prefer-active-python true

--- a/scripts/install-poetry.sh
+++ b/scripts/install-poetry.sh
@@ -30,3 +30,6 @@ esac
 poetry config virtualenvs.create true
 poetry config virtualenvs.in-project true
 poetry config virtualenvs.prefer-active-python true
+
+pipx inject poetry poetry-plugin-export;
+poetry config warnings.export false;


### PR DESCRIPTION
# Summary

Replace the use of `Gr1N/setup-poetry` with `pipx` to install `poetry`.

# Why This Is Needed

Enables installation of poetry plugins (#165) on all OS's following poetry's recommendations.

# What Changed

## Added

- added steps to install poetry with `pipx`, cache `pipx`, configure `poetry`, and install `poetry-plugin-export`

## Changed

- input for `poetry-version` changed slightly, see description/docs

## Removed

- removed the use of `Gr1N/setup-poetry`