### PR TITLE
remove `Ensure cache is healthy` step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,14 +137,6 @@ runs:
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.composite-setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}${{ inputs.cache-key-suffix }}
-    - name: Ensure cache is healthy
-      if: |
-        always() &&
-        inputs.ensure-cache-is-healthy == 'true' &&
-        runner.os != 'Windows' &&
-        steps.composite-python-venv-cache.outputs.cache-hit == 'true'
-      run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
-      shell: bash
     - name: Check pyproject.toml & poetry.lock
       if: inputs.poetry-check == 'true'
       env:


### PR DESCRIPTION
# Summary

Remove the `Ensure cache is healthy` step as modern versions of `poetry` perform a health check on the virtual environment before use, recreating it if needed.

# What Changed

## Removed

- removed the `Ensure cache is healthy`  step