### PR TITLE
change default value of `poetry-check` to `false`

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -68,9 +68,7 @@ jobs:
         run: poetry self show plugins | grep poetry-plugin-export
   test-local-action-no-plugins:
     # This has to be run after the miss as the cache is not uploaded until the
-    # the job is finished.
-    name: Test Local Action With Cache Hit
-    needs: test-local-action
+    name: Test Local Action without plugins
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   poetry-check:
     description: Whether validate the content of the `pyproject.toml` file and its consistency with the `poetry.lock` file.
     required: false
-    default: true
+    default: false
   poetry-check-cmd:
     description: |
       The poetry command to run when checking the lock file (e.g. `check`).


### PR DESCRIPTION
# Summary

The `poetry-check` now defaults to `false` as the check is now performed during `poetry install`, resulting in an error (https://github.com/python-poetry/poetry/pull/8737).

# What Changed

## Changed

- default value of `poetry-check` is now `false`
